### PR TITLE
Updated prompt in createDocBlock to specify detailed PHPDoc instructions

### DIFF
--- a/src/DocumentationGenerator.php
+++ b/src/DocumentationGenerator.php
@@ -16,9 +16,11 @@ class DocumentationGenerator
 
         $openai = \OpenAI::client($key);
 
+        $prompt = "Read the following PHP function: " . $function . ". Write the PHPDoc block in English for the method named " . $function . ", remove any unnecessary code and comments, including if it's an empty constructor. Do not add any additional comments except for the required PHPDocs, unless you detect obvious errors.";
+
         $completion = $openai->completions()->create([
-            'model' => 'text-davinci-003',
-            'prompt' => 'Read the following PHP function: """ '.$function.' """ PHPDoc block for the function:',
+            'model' => 'gpt-3.5-turbo-instruct',
+            'prompt' => $prompt,
             'max_tokens' => 1024,
             'stop' => ['"""'],
             'temperature' => 0.3
@@ -36,6 +38,4 @@ class DocumentationGenerator
             throw new \RuntimeException('An error occurred while trying to get the doc block: ' . $e->getMessage());
         }
     }
-
-
 }


### PR DESCRIPTION
Modified the `createDocBlock` method in the DocumentationGenerator class to update the prompt for the OpenAI API call. The new prompt clearly specifies that the PHPDoc block should be written in English, unnecessary code and comments should be removed, and no additional comments should be added unless clear errors are detected. This update ensures the generated documentation is precise and relevant to the provided PHP function. Also updated the OpenAI model to 'gpt-3.5-turbo-instruct' to improve the quality of the documentation output.
